### PR TITLE
Remove hidden advertising

### DIFF
--- a/rest_wind/templates/rest_framework/base.html
+++ b/rest_wind/templates/rest_framework/base.html
@@ -616,13 +616,13 @@
             <section id="response" class="card rounded-box bg-base-200">
               <header class="flex items-center justify-between gap-4 px-4 py-2 rounded-t-box bg-base-300">
                 <div class="flex items-center gap-2">
-                  <div class="tooltip tooltip-top tooltip-error" data-tip="{% translate 'DRF' %}">
+                  <div class="tooltip tooltip-top tooltip-error">
                     <div class="size-5 rounded-full bg-red-400 lg:size-6"></div>
                   </div>
-                  <div class="tooltip tooltip-top tooltip-warning" data-tip="{% translate '+' %}">
+                  <div class="tooltip tooltip-top tooltip-warning">
                     <div class="size-5 rounded-full bg-yellow-400 lg:size-6"></div>
                   </div>
-                  <div class="tooltip tooltip-top tooltip-success" data-tip="{% translate 'Django' %}">
+                  <div class="tooltip tooltip-top tooltip-success">
                     <div class="size-5 rounded-full bg-green-400 lg:size-6"></div>
                   </div>
                 </div>


### PR DESCRIPTION
Thanks for making this project available as a successor in spirit to drf-redesign, also with better customizing options. While testing I found the three hidden tooltips with the "We love Django", "DRF Rocks", "Made by youzarsiph" tooltips. :-)

I feel, if citation is wanted, it should be more explicit and not sneaked in like this. At least it should be mentioned in the README and probably be customizable, too, without having to replace the whole base.html template. This commit removes the tooltip texts but feel free to come up with a better solution.

Somehow I couldn't find the message catalogue with the translations texts. Is it missing in the git repo?

KR, Dennis